### PR TITLE
fix android 2.x scroll but break other browsers

### DIFF
--- a/dist/ratchet.css
+++ b/dist/ratchet.css
@@ -101,7 +101,7 @@ html {
 -------------------------------------------------- */
 
 body {
-  position: fixed;
+  overflow: scroll;
   top: 0;
   right: 0;
   bottom: 0;
@@ -120,11 +120,9 @@ a {
 
 /* Wrapper to be used around all content not in .bar-title and .bar-tab */
 .content {
-  position: fixed;
+  position: absolute;
   top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  width: 100%;
   overflow: auto;
   background-color: #fff;
   -webkit-transition-property: top, bottom;
@@ -154,7 +152,7 @@ a {
   top: 44px;
 }
 .bar-tab ~ .content {
-  bottom: 51px;
+  margin-bottom: 51px;
 }
 .bar-header-secondary ~ .content {
   top: 88px;

--- a/lib/css/base.css
+++ b/lib/css/base.css
@@ -93,7 +93,7 @@ html {
 -------------------------------------------------- */
 
 body {
-  position: fixed;
+  overflow: scroll;
   top: 0;
   right: 0;
   bottom: 0;
@@ -112,11 +112,9 @@ a {
 
 /* Wrapper to be used around all content not in .bar-title and .bar-tab */
 .content {
-  position: fixed;
+  position: absolute;
   top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  width: 100%;
   overflow: auto;
   background-color: #fff;
   -webkit-transition-property: top, bottom;
@@ -146,7 +144,7 @@ a {
   top: 44px;
 }
 .bar-tab ~ .content {
-  bottom: 51px;
+  margin-bottom: 51px;
 }
 .bar-header-secondary ~ .content {
   top: 88px;


### PR DESCRIPTION
here is high definition video proof http://www.youtube.com/watch?v=bekfcazGqsw

the downside of this pull request is that it breaks ios compatibility. :cat2: :cat2: :cat2: 

I figured I should make this pull req anyway so that there is a historical record of the weird shit android 2 browser does. in @gather i have to use JS to set the correct styles https://github.com/maxogden/ViewKit/blob/master/lib/components/list/list.css#L2-5 but I didnt wanna add any more new hacks to this repo so i'll let you figure it out
