### PR TITLE
README troubleshooting update with file:/// protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ Please file a Github issue to [report a bug](http://github.com/maker/ratchet/iss
 
 ## Troubleshooting
 
-A small list of "gotchas" are provided below for developers starting to work with Ratchet
+A small list of "gotchas" are provided below for designers and developers starting to work with Ratchet
 
 - Ratchet is designed to respond to touch events from a mobile device. In order to use mouse click events (for desktop browsing and testing), you have a few options:
     - Enable touch event emulation in Chrome (found in the overrides tab in the web inspector preferences)
-    - Use a javascript library like fingerblast.js to emulate touch events (depending on the user agent)
+    - Use a javascript library like fingerblast.js to emulate touch events (ideally only loaded from desktop devices)
 - Script tags containing javascript will not be executed on pages that are loaded with push.js. If you would like to attach event handlers to elements on other pages, document-level event delegation is a common solution.
+- Ratchet uses XHR requests to fetch additional pages inside the application. Due to security concerns, modern browsers prevent XHR requests when opening files locally (aka using the file:/// protocol); consequently, Ratchet does not work when opened directly as a file.
+    - A common solution to this is to simply serve the files from a local server. One convenient way to achieve this is to run ```python -m SimpleHTTPServer <port>``` to serve up the files in the current directory to ```http://localhost:<port>```
 
 ## Future features
 


### PR DESCRIPTION
One more gotcha to add to the list! I just helped out another student at Berkeley who was stuck due to this issue. The console fires a ton of errors that makes this pretty obvious, but since people with a wide range of experience will (ideally) be using Ratchet, I figure it's worth disclosing.

Displayed here for convenience. Also included some minor language updates. Hopefully this last one covers all our bases:
- Ratchet uses XHR requests to fetch additional pages inside the application. Due to security concerns, modern browsers prevent XHR requests when opening files locally (aka using the file:/// protocol); consequently, Ratchet does not work when opened directly as a file.
  - A common solution to this is to simply serve the files from a local server. One convenient way to achieve this is to run `python -m SimpleHTTPServer <port>` to serve up the files in the current directory to `http://localhost:<port>`
