### PR TITLE
Initial CSS additions for Shelf Nav Item

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 build:
 	mkdir -p dist
-	cat lib/css/base.css lib/css/bars.css lib/css/lists.css lib/css/forms.css lib/css/buttons.css lib/css/chevrons.css lib/css/counts.css lib/css/segmented-controllers.css lib/css/popovers.css lib/css/sliders.css lib/css/toggles.css lib/css/push.css > ./dist/ratchet.tmp.css
+	cat lib/css/base.css lib/css/bars.css lib/css/lists.css lib/css/forms.css lib/css/buttons.css lib/css/chevrons.css lib/css/counts.css lib/css/segmented-controllers.css lib/css/popovers.css lib/css/sliders.css lib/css/toggles.css lib/css/push.css lib/css/shelf.css > ./dist/ratchet.tmp.css
 	cat lib/js/*.js > ./dist/ratchet.tmp.js
 	@echo "/**\n * ==================================\n * Ratchet v1.0.0\n * Licensed under The MIT License\n * http://opensource.org/licenses/MIT\n * ==================================\n */\n" > ./dist/copywrite.txt
 	cat ./dist/copywrite.txt ./dist/ratchet.tmp.js  > ./dist/ratchet.js

--- a/dist/ratchet.css
+++ b/dist/ratchet.css
@@ -127,12 +127,12 @@ a {
   left: 0;
   overflow: auto;
   background-color: #fff;
-  -webkit-transition-property: top, bottom;
-          transition-property: top, bottom;
-  -webkit-transition-duration: .2s, .2s;
-          transition-duration: .2s, .2s;
-  -webkit-transition-timing-function: linear, linear;
-          transition-timing-function: linear, linear;
+  -webkit-transition-property: top, bottom, translate3d;
+          transition-property: top, bottom, translate3d;
+  -webkit-transition-duration: .2s, .2s, .2s;
+          transition-duration: .2s, .2s, .2s;
+  -webkit-transition-timing-function: linear, linear, ease-out;
+          transition-timing-function: linear, linear, ease-out;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -212,6 +212,13 @@ a {
   box-shadow: inset 0 1px 1px -1px rgba(255, 255, 255, .8);
   -webkit-box-orient: horizontal;
           box-orient: horizontal;
+
+  -webkit-transition-property: translate3d;
+          transition-property: translate3d;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  -webkit-transition-timing-function: ease-out;
+          transition-timing-function: ease-out;
 }
 
 /* Centered text in the .bar-title */
@@ -255,6 +262,13 @@ a {
   border-top: 1px solid #000;
   border-bottom-width: 0;
   box-shadow: inset 0 1px 1px -1px rgba(255, 255, 255, .6);
+
+  -webkit-transition-property: translate3d;
+          transition-property: translate3d;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  -webkit-transition-timing-function: ease-out;
+          transition-timing-function: ease-out;
 }
 
 /* Wrapper for individual tab */
@@ -1257,4 +1271,61 @@ select {
 .content.slide.right {
   -webkit-transform: translate3d(100%, 0, 0);
           transform: translate3d(100%, 0, 0);
+}/* Shelf
+-------------------------------------------------- */
+/* Exposable shelf docked to the left for primary app navigation */
+.shelf {
+  position: fixed;
+  z-index: 10;
+  box-sizing: border-box;
+
+  top: 0px;
+  left: 0px;
+
+  /* it would be great to use a percentage here for the width, but our
+    hide and show animations are based on -webkit-transform which needs
+    a pixel translation amount */
+  width: 200px;
+  height: 100%;
+
+  background-color: #393939;
+  background-image: -webkit-linear-gradient(top, #393939 0, #2b2b2b 100%);
+  background-image: linear-gradient(to bottom, #393939 0, #2b2b2b 100%);
+  border-top: 1px solid #000;
+  border-bottom-width: 0;
+  box-shadow: inset 0 0px 20px 0px rgba(0, 0, 0, .6);
+
+  /* hide it normally */
+  -webkit-transform: translate3d(-200px, 0, 0);
+          transform: translate3d(-200px, 0, 0);
+
+  -webkit-transition-property: translate3d;
+          transition-property: translate3d;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  -webkit-transition-timing-function: ease-out;
+          transition-timing-function: ease-out;
+}
+
+.shelf.exposed {
+  -webkit-transform: translate3d(0px, 0, 0);
+          transform: translate3d(0px, 0, 0);
+}
+
+body.shelf_exposed .bar-title, body.shelf_exposed .content, body.shelf_exposed .bar-tab {
+  -webkit-transform: translate3d(200px, 0, 0);
+          transform: translate3d(200px, 0, 0);
+}
+
+/* Overrides when items are in the shelf */
+.shelf .tab-inner {
+  width: 100%;
+  height: auto;
+  -webkit-box-orient: vertical;
+          box-orient: vertical;
+}
+
+/* Padding all around is now needed when tab items are in a shelf */
+.shelf .tab-item {
+  padding: 20px;
 }

--- a/lib/css/bars.css
+++ b/lib/css/bars.css
@@ -52,6 +52,13 @@
   box-shadow: inset 0 1px 1px -1px rgba(255, 255, 255, .8);
   -webkit-box-orient: horizontal;
           box-orient: horizontal;
+
+  -webkit-transition-property: translate3d;
+          transition-property: translate3d;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  -webkit-transition-timing-function: ease-out;
+          transition-timing-function: ease-out;
 }
 
 /* Centered text in the .bar-title */
@@ -95,6 +102,13 @@
   border-top: 1px solid #000;
   border-bottom-width: 0;
   box-shadow: inset 0 1px 1px -1px rgba(255, 255, 255, .6);
+
+  -webkit-transition-property: translate3d;
+          transition-property: translate3d;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  -webkit-transition-timing-function: ease-out;
+          transition-timing-function: ease-out;
 }
 
 /* Wrapper for individual tab */

--- a/lib/css/base.css
+++ b/lib/css/base.css
@@ -119,12 +119,12 @@ a {
   left: 0;
   overflow: auto;
   background-color: #fff;
-  -webkit-transition-property: top, bottom;
-          transition-property: top, bottom;
-  -webkit-transition-duration: .2s, .2s;
-          transition-duration: .2s, .2s;
-  -webkit-transition-timing-function: linear, linear;
-          transition-timing-function: linear, linear;
+  -webkit-transition-property: top, bottom, translate3d;
+          transition-property: top, bottom, translate3d;
+  -webkit-transition-duration: .2s, .2s, .2s;
+          transition-duration: .2s, .2s, .2s;
+  -webkit-transition-timing-function: linear, linear, ease-out;
+          transition-timing-function: linear, linear, ease-out;
   -webkit-overflow-scrolling: touch;
 }
 

--- a/lib/css/shelf.css
+++ b/lib/css/shelf.css
@@ -1,0 +1,58 @@
+/* Shelf
+-------------------------------------------------- */
+/* Exposable shelf docked to the left for primary app navigation */
+.shelf {
+  position: fixed;
+  z-index: 10;
+  box-sizing: border-box;
+
+  top: 0px;
+  left: 0px;
+
+  /* it would be great to use a percentage here for the width, but our
+    hide and show animations are based on -webkit-transform which needs
+    a pixel translation amount */
+  width: 200px;
+  height: 100%;
+
+  background-color: #393939;
+  background-image: -webkit-linear-gradient(top, #393939 0, #2b2b2b 100%);
+  background-image: linear-gradient(to bottom, #393939 0, #2b2b2b 100%);
+  border-top: 1px solid #000;
+  border-bottom-width: 0;
+  box-shadow: inset 0 0px 20px 0px rgba(0, 0, 0, .6);
+
+  /* hide it normally */
+  -webkit-transform: translate3d(-200px, 0, 0);
+          transform: translate3d(-200px, 0, 0);
+
+  -webkit-transition-property: translate3d;
+          transition-property: translate3d;
+  -webkit-transition-duration: .2s;
+          transition-duration: .2s;
+  -webkit-transition-timing-function: ease-out;
+          transition-timing-function: ease-out;
+}
+
+.shelf.exposed {
+  -webkit-transform: translate3d(0px, 0, 0);
+          transform: translate3d(0px, 0, 0);
+}
+
+body.shelf_exposed .bar-title, body.shelf_exposed .content, body.shelf_exposed .bar-tab {
+  -webkit-transform: translate3d(200px, 0, 0);
+          transform: translate3d(200px, 0, 0);
+}
+
+/* Overrides when items are in the shelf */
+.shelf .tab-inner {
+  width: 100%;
+  height: auto;
+  -webkit-box-orient: vertical;
+          box-orient: vertical;
+}
+
+/* Padding all around is now needed when tab items are in a shelf */
+.shelf .tab-item {
+  padding: 20px;
+}


### PR DESCRIPTION
Hey everyone (Dave / Connor / Jacob?)!

This is the first half of getting the shelf navigation item working. See a recorded demo here:

https://vimeo.com/53781844

Or this rather ugly screencap below:

<img src="http://i.imgur.com/A4RuD.png"/>

The high level idea behind how the shelf will work:
- The shelf navigation element always exists, it just has a CSS attribute to hide it normally
- A shelf nav item that receives the  css class `exposed` will translate into view
- Adding the css class `shelf_exposed` to the body element will translate bar-titles, bar-tabs, and the div.content to the side. Essentially this class on body acts as a global "a shelf is shown" variable.
- Since each shelf is exposed individually but the entire viewport is translated globally, you can have multiple shelves

After this, I'll just need to add the JS that triggers these classes for a given link.
