### PR TITLE
Added error handling to popover check.

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -47,7 +47,12 @@
 
     if (!anchor || !anchor.hash) return;
 
-    popover = document.querySelector(anchor.hash);
+    try{
+      popover = document.querySelector(anchor.hash);
+    }
+    catch {
+      popover = {}
+    }
 
     if (!popover || !popover.classList.contains('popover')) return;
 


### PR DESCRIPTION
popover was returning the following error in my app:

Uncaught Error: SYNTAX_ERR: DOM Exception 12 ratchet.js:50
