### PR TITLE
Fix Uncaught TypeError: Cannot call method 'contains' of undefined caused by Fix in 119f1f6

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -70,9 +70,16 @@
     var anchor = findPopovers(e.target);
 
     if (!anchor || !anchor.hash) return;
+    
+    try{
+ 	 	popover = document.querySelector(anchor.hash);
+ 	}
+ 	catch (error) {
+ 		popover = null;
+ 	}
 
-    popover = document.querySelector(anchor.hash);
-
+ 	if (popover == null) return;
+ 	
     if (!popover || !popover.classList.contains('popover')) return;
 
     return popover;


### PR DESCRIPTION
...and fixed the resulting error Uncaught TypeError: Cannot call method 'contains' of undefined
