### PR TITLE
Make sure PUSH.xhr is set so duplicate push requests can be prevented.

### DIFF
--- a/lib/js/push.js
+++ b/lib/js/push.js
@@ -182,6 +182,7 @@
     var key;
     var data = {};
     var xhr  = PUSH.xhr;
+    var abortedLast = false;
 
     options.container = options.container || options.transition ? document.querySelector('.content') : document.body;
 
@@ -191,10 +192,12 @@
 
     if (xhr && xhr.readyState < 4) {
       xhr.onreadystatechange = noop;
-      xhr.abort()
+      xhr.abort();
+      abortedLast = true;
     }
 
     xhr = new XMLHttpRequest();
+    PUSH.xhr = xhr;
     xhr.open('GET', options.url, true);
     xhr.setRequestHeader('X-PUSH', 'true');
 
@@ -219,7 +222,7 @@
 
     xhr.send();
 
-    if (xhr.readyState && !options.ignorePush) cachePush();
+    if (xhr.readyState && !options.ignorePush && !abortedLast) cachePush();
   };
 
 


### PR DESCRIPTION
PUSH.xhr is checked for the existence of a previous
request but it is never set. This patch makes sure it
is set so a race condition where multiple push requests
stomp on each other is avoided.

This also prevents the call the cachePush if the previous
request was abort to avoid the stack getting out of sync
with requests that actually completed.
