### PR TITLE
Ensure taps aren't accidentally sent to the modal

### DIFF
--- a/lib/js/modals.js
+++ b/lib/js/modals.js
@@ -19,6 +19,7 @@
   };
 
   window.addEventListener('touchend', function (event) {
+    event.stopPropagation();
     var modal = getModal(event);
     if (modal) modal.classList.toggle('active');
   });


### PR DESCRIPTION
Without stopping the propagation of the event which pops up the modal,
it was possible for the modal itself to receive the same event.
