### PR TITLE
Fixed a bug in Segmented controller when swapping content sections back and forth

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -551,7 +551,7 @@
 
     activeBodies = targetBody.parentNode.querySelectorAll(classSelector);
 
-    for (var i = 0; i < activeBodies.length; i++){
+    for (var i = 0; i < activeBodies.length; i++) {
       activeBodies[i].classList.remove(className);
     }
 

--- a/lib/js/segmented-controllers.js
+++ b/lib/js/segmented-controllers.js
@@ -38,7 +38,7 @@
 
     activeBodies = targetBody.parentNode.querySelectorAll(classSelector);
 
-    for (var i = 0; i < activeBodies.length; i++){
+    for (var i = 0; i < activeBodies.length; i++) {
       activeBodies[i].classList.remove(className);
     }
 


### PR DESCRIPTION
Bug in Segmented controller: when swapping content sections back and forth, later section is appended to the bottom of previous section.

This bug is fixed by removing the 'active' class from all segmented-controller-items.
