### PR TITLE
remove backdrop from proper element.

### DIFF
--- a/lib/js/popovers.js
+++ b/lib/js/popovers.js
@@ -16,7 +16,7 @@
   };
 
   var onPopoverHidden = function () {
-    document.body.removeChild(backdrop);
+    popover.parentNode.removeChild(backdrop);
     popover.style.display = 'none';
     popover.removeEventListener('webkitTransitionEnd', onPopoverHidden);
   }
@@ -46,7 +46,7 @@
     return popover;
   }
 
-  window.addEventListener('touchend', function (e) {
+  var showHidePopover = function (e) {
     var popover = getPopover(e);
 
     if (!popover) return;
@@ -56,8 +56,9 @@
     popover.classList.add('visible');
 
     popover.parentNode.appendChild(backdrop);
-  });
+  };
 
-  window.addEventListener('click', function (e) { if (getPopover(e)) e.preventDefault(); });
+  window.addEventListener('touchend', showHidePopover);
+  window.addEventListener('click', showHidePopover);
 
 }();


### PR DESCRIPTION
When a popover is displayed, a backdrop is appened to the popovers parent node.

We need to remove it from that node instead of assuming that node will be `document.body`
