### PR TITLE
Fix sliders delta initialization

### DIFF
--- a/lib/js/sliders.js
+++ b/lib/js/sliders.js
@@ -56,6 +56,8 @@
     startTime      = +new Date;
     pageX          = e.touches[0].pageX;
     pageY          = e.touches[0].pageY;
+	deltaX         = 0;
+	deltaY         = 0;
 
     setSlideNumber(0);
 


### PR DESCRIPTION
Initialize deltaX and deltaY after each slide (in touchend event) to avoid unwanted slide (with a simple touch by example).
