### PR TITLE
Push example now works with Firefox

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -301,7 +301,7 @@
 
     if (!PUSH.id) {
       cacheReplace({
-        id         : new Date(),
+        id         : +new Date,
         url        : window.location.href,
         title      : document.title,
         timeout    : options.timeout,
@@ -417,7 +417,7 @@
       container.classList.add(containerDirection);
       swap.classList.remove(swapDirection);
 
-      var slideEnd = function () {
+      function slideEnd () {
         swap.removeEventListener('webkitTransitionEnd', slideEnd);
         swap.classList.remove('slide');
         swap.classList.remove(swapDirection);


### PR DESCRIPTION
When running the push example in Firefox (21.0), there is 2 issues:
- transition is not executed: the new page is not loaded
- location of the page is not updated (it becomes http://maker.github.io/ratchet/undefined)

this patch corrects those 2 issues.
