### PR TITLE
Restrict sliders to only top-level ul elements

### DIFF
--- a/lib/js/sliders.js
+++ b/lib/js/sliders.js
@@ -22,7 +22,7 @@
   var scrollableArea;
 
   var getSlider = function (target) {
-    var i, sliders = document.querySelectorAll('.slider ul');
+    var i, sliders = document.querySelectorAll('.slider > ul');
     for (; target && target !== document; target = target.parentNode) {
       for (i = sliders.length; i--;) { if (sliders[i] === target) return target; }
     }


### PR DESCRIPTION
Currently, markup like the following results in strange and unexpected slider behavior:

``` html
<div class="slider">
  <ul>
    <li>
      <ul>
        <li>
          <p>Hi</p>
        </li>
      </ul>
      <p>Hi again</p>
    </li>
  </ul>
</div>
```

Essentially, if your slider contains content with another `<ul>`, an extra sub slider is created. This contradicts the behavior implied in the stylesheet, which scopes the slider to `.slider > ul`. This PR corrects that in JavaScript.

(thx @kyledoherty)
