### PR TITLE
Fix issue when after sliding, a touch event triggers sliding

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -577,6 +577,7 @@
   var slideNumber;
   var isScrolling;
   var scrollableArea;
+  var hasMoved;
 
   var getSlider = function (target) {
     var i, sliders = document.querySelectorAll('.slider ul');
@@ -626,6 +627,7 @@
     deltaY = e.touches[0].pageY - pageY;
     pageX  = e.touches[0].pageX;
     pageY  = e.touches[0].pageY;
+    hasMoved = true;
 
     if (typeof isScrolling == 'undefined') {
       isScrolling = Math.abs(deltaY) > Math.abs(deltaX);
@@ -644,7 +646,7 @@
   };
 
   var onTouchEnd = function (e) {
-    if (!slider || isScrolling) return;
+    if (!slider || isScrolling || !hasMoved) return;
 
     setSlideNumber(
       (+new Date) - startTime < 1000 && Math.abs(deltaX) > 15 ? (deltaX < 0 ? -1 : 1) : 0
@@ -662,6 +664,7 @@
     });
 
     slider.parentNode.dispatchEvent(e);
+    hasMoved = false
   };
 
   window.addEventListener('touchstart', onTouchStart);

--- a/lib/js/sliders.js
+++ b/lib/js/sliders.js
@@ -20,6 +20,7 @@
   var slideNumber;
   var isScrolling;
   var scrollableArea;
+  var hasMoved;
 
   var getSlider = function (target) {
     var i, sliders = document.querySelectorAll('.slider ul');
@@ -69,6 +70,7 @@
     deltaY = e.touches[0].pageY - pageY;
     pageX  = e.touches[0].pageX;
     pageY  = e.touches[0].pageY;
+    hasMoved = true;
 
     if (typeof isScrolling == 'undefined') {
       isScrolling = Math.abs(deltaY) > Math.abs(deltaX);
@@ -87,7 +89,7 @@
   };
 
   var onTouchEnd = function (e) {
-    if (!slider || isScrolling) return;
+    if (!slider || isScrolling || !hasMoved) return;
 
     setSlideNumber(
       (+new Date) - startTime < 1000 && Math.abs(deltaX) > 15 ? (deltaX < 0 ? -1 : 1) : 0
@@ -105,6 +107,7 @@
     });
 
     slider.parentNode.dispatchEvent(e);
+    hasMoved = false
   };
 
   window.addEventListener('touchstart', onTouchStart);


### PR DESCRIPTION
This pull request fixes an issue with the slider. The issue occurs when sliding and then touching the slider after the next (prev) slide has become the current slide. Subsequent touch events cause the slider to move to next (prev) slide. This doesn't appear to be desired behavior since any touch event on the slide causes it to jump to next (prev) slide, and disables any potential touch/click events on UI elements within the current slide.
