### PR TITLE
Fixed Hash Override in Modal

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -28,7 +28,10 @@
 
   window.addEventListener('touchend', function (event) {
     var modal = getModal(event);
-    if (modal) modal.classList.toggle('active');
+    if (modal) {
+      modal.classList.toggle('active');
+      event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
+    }
   });
 }();/* ----------------------------------
  * POPOVER v1.0.0

--- a/lib/js/modals.js
+++ b/lib/js/modals.js
@@ -20,6 +20,9 @@
 
   window.addEventListener('touchend', function (event) {
     var modal = getModal(event);
-    if (modal) modal.classList.toggle('active');
+    if (modal) {
+      modal.classList.toggle('active');
+      event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
+    }
   });
 }();


### PR DESCRIPTION
Allows users to still modify hash values in the url (otherwise DOM error)
