### PR TITLE
Remove `type` and fix URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,4 @@ authors: Connor Sears, Dave Gamache, and Jacob Thornton
 description: Prototype iPhone apps with simple HTML, CSS, and JS components.
 url: http://maker.github.io/ratchet
 
-pygments:         true
+pygments: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,8 +19,7 @@
 <script src="dist/ratchet.js"></script>
 <script src="assets/js/docs.js"></script>
 <script src="assets/js/fingerblast.js"></script>
-<script type="text/javascript">
-
+<script>
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-36050008-1']);
   _gaq.push(['_trackPageview']);
@@ -30,5 +29,4 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
-
 </script>

--- a/one.html
+++ b/one.html
@@ -13,8 +13,8 @@
     <link rel="stylesheet" href="css/docs.css">
     <link rel="stylesheet" href="css/prettify.css">
     <!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
-    <script type="text/javascript" src="//use.typekit.net/gwz1sef.js"></script>
-    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+    <script src="https://use.typekit.net/gwz1sef.js"></script>
+    <script>try{Typekit.load();}catch(e){}</script>
     <style>
       .iphone [class*="bar"] {
         position: absolute;

--- a/two.html
+++ b/two.html
@@ -6,15 +6,15 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
-    <link rel="shortcut icon" href="favicon.ico"/>
+    <link rel="shortcut icon" href="favicon.ico">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <link rel="stylesheet" href="../dist/ratchet.css">
     <link rel="stylesheet" href="css/docs.css">
     <link rel="stylesheet" href="css/prettify.css">
     <!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
-    <script type="text/javascript" src="//use.typekit.net/gwz1sef.js"></script>
-    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+    <script src="https://use.typekit.net/gwz1sef.js"></script>
+    <script>try{Typekit.load();}catch(e){}</script>
     <style>
       .iphone [class*="bar"] {
         position: absolute;


### PR DESCRIPTION
This is just a little fix to remove unneeded `type` attributes and fix URLs (don't keep them `//`, they should be with `https://` || `http://`).
