### PR TITLE
Fix when #resource/id url paths

### DIFF
--- a/dist/ratchet.js
+++ b/dist/ratchet.js
@@ -72,7 +72,7 @@
   var getPopover = function (e) {
     var anchor = findPopovers(e.target);
 
-    if (!anchor || !anchor.hash) return;
+    if (!anchor || !anchor.hash || (anchor.hash.indexOf("/") > 0)) return;
 
     popover = document.querySelector(anchor.hash);
 
@@ -121,7 +121,7 @@
     'slide-out' : 'slide-in',
     'fade'      : 'fade'
   };
-  
+
   var bars = {
     bartab             : '.bar-tab',
     bartitle           : '.bar-title',

--- a/lib/js/popovers.js
+++ b/lib/js/popovers.js
@@ -37,7 +37,7 @@
   var getPopover = function (e) {
     var anchor = findPopovers(e.target);
 
-    if (!anchor || !anchor.hash) return;
+    if (!anchor || !anchor.hash || (anchor.hash.indexOf("/") > 0)) return;
 
     popover = document.querySelector(anchor.hash);
 


### PR DESCRIPTION
getPopover function fail when using #resource/id url paths, typically used on backbone.js projects. This PR fixes that bug.
