### PR TITLE
Fix typo: change cource to source

### DIFF
--- a/docs/_includes/download-module.html
+++ b/docs/_includes/download-module.html
@@ -1,5 +1,5 @@
 <div class="docs-module">
   <h4 class="docs-module-title">Download Ratchet</h4>
-  <p>If you haven't already, download the cource code for Ratchet.</p>
+  <p>If you haven't already, download the source code for Ratchet.</p>
   <a href="https://github.com/twbs/ratchet/archive/v2.0.0.zip" class="btn btn-block btn-primary" data-ignore="push" onClick="_gaq.push(['_trackEvent', 'Downloads', 'V2.0']);">Download Ratchet</a>
 </div>


### PR DESCRIPTION
Fixed the typo in the download page for cource to source.
