### PR TITLE
use load-grunt-tasks to load Grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,11 +79,7 @@ module.exports = function(grunt) {
   });
 
   // Load the plugins
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-sass');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-jekyll');
+  require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
 
 
   // Default task(s).

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-contrib-nodeunit": "~0.3.0",
     "grunt-contrib-sass": "~0.7.1",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-jekyll": "~0.4.1"
+    "grunt-jekyll": "~0.4.1",
+    "load-grunt-tasks": "~0.4.0"
   }
 }


### PR DESCRIPTION
Avoids having to redundantly list the tasks in both `package.json` and the Gruntfile.
