### PR TITLE
use HTTPS for CDN assets in docs

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -8,7 +8,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
 <!-- Roboto -->
-<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:400,700,500">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700,500">
 
 <link rel="stylesheet" href="../dist/ratchet.css">
 <link rel="stylesheet" href="../assets/css/docs.css">
@@ -27,7 +27,7 @@
 <script src="../assets/js/fingerblast.js"></script>
 
 <!-- Typekit -->
-<script src="//use.typekit.net/asj6ttm.js"></script>
+<script src="https://use.typekit.net/asj6ttm.js"></script>
 <script>try{Typekit.load();}catch(e){}</script>
 
 <script>

--- a/docs/examples/app-android-notes/index.html
+++ b/docs/examples/app-android-notes/index.html
@@ -14,7 +14,7 @@
 
 
     <!-- Roboto -->
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,700,500' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,700,500' rel='stylesheet' type='text/css'>
   </head>
   <body>
     <header class="bar bar-nav">


### PR DESCRIPTION
This avoids security warnings and makes `file://`-viewing less broken.
