### PR TITLE
Remove `port: 4000`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,4 +11,3 @@ permalink:    pretty
 
 # Server
 source:       ./docs
-port:         4000


### PR DESCRIPTION
Jekyll default settings includes `port: 4000`. Don't re-set them.
