### PR TITLE
Update header.html

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,4 +1,5 @@
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <title>{{ page.title }}</title>
 <meta name="description" content="{{ site.name }}: {{ site.description }}">
 <meta name="author" content="{{ site.authors }}">


### PR DESCRIPTION
Add <meta http-equiv="X-UA-Compatible" content="IE=edge"> to prevent versions of IE from rendering in quirks mode (which breaks the docs in IE9)
