### PR TITLE
Only use font-weight: 100 on retina screens

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -665,6 +665,7 @@ body {
 code {
   padding: 2px 4px;
   font-size: 90%;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   background-color: #f9f9f9;
   border-radius: 3px;
 }

--- a/sass/docs.scss
+++ b/sass/docs.scss
@@ -697,6 +697,7 @@ body {
 code {
   padding: 2px 4px;
   font-size: 90%;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   background-color: #f9f9f9;
   border-radius: 3px;
 }


### PR DESCRIPTION
Use media queries to only show `font-weight: 100` on retina screens.

Fixes: #310 

cc: @XhmikosR
