### PR TITLE
Revamp docs JS

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -6,11 +6,9 @@
     </li>
     <li>
       <a data-ignore="push" href="https://twitter.com/share" class="twitter-share-button" data-url="http://goratchet.com" data-text="Ratchet &#8211; Build mobile apps with simple HTML, CSS, and JS components." data-via="GoRatchet">Tweet</a>
-      <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     </li>
     <li><a data-ignore="push" href="https://twitter.com/GoRatchet" class="twitter-follow-button" data-show-count="true">
       Follow @GoRatchet</a>
-      <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     </li>
   </ul>
 
@@ -26,3 +24,26 @@
     <li><a href="http://goratchet.com/1.0.2/" data-ignore="push">Legacy v1.0.2 Docs</a></li>
   </ul>
 </div>
+
+{% comment %}
+  Inject Twitter widgets asynchronously. Snippet snipped from Twitter's
+  JS interface site: https://dev.twitter.com/docs/tfw-javascript
+
+  * "js.async=1;" added to add async attribute to the generated script tag.
+{% endcomment %}
+<script>
+  window.twttr = (function (d,s,id) {
+    var t, js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return; js=d.createElement(s); js.id=id; js.async=1;
+    js.src="https://platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs);
+    return window.twttr || (t = { _e: [], ready: function(f){ t._e.push(f) } });
+  }(document, "script", "twitter-wjs"));
+</script>
+
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="/dist/ratchet.js"></script>
+<script src="/assets/js/docs.js"></script>
+<script src="/assets/js/fingerblast.js"></script>
+
+<script src="//use.typekit.net/asj6ttm.js"></script>
+<script>try{Typekit.load();}catch(e){}</script>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -22,15 +22,6 @@
 
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/img/apple-touch-icon-114x114.png">
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-<script src="/dist/ratchet.js"></script>
-<script src="/assets/js/docs.js"></script>
-<script src="/assets/js/fingerblast.js"></script>
-
-<!-- Typekit -->
-<script src="//use.typekit.net/asj6ttm.js"></script>
-<script>try{Typekit.load();}catch(e){}</script>
-
 <script>
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-36050008-1']);


### PR DESCRIPTION
- Move JS to the footer
- Dedupe the JS needed for the Twitter tweet and follow buttons

Both of these is how Bootstrap does it. Sadly there's no benefit on page file size, but it reduces the JS for each button at least.
