### PR TITLE
Make gitignore consistent with Bootstrap's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ignore docs files
+_gh_pages
+_site
+.ruby-version
+
 # Numerous always-ignore extensions
 *.diff
 *.err
@@ -9,7 +14,6 @@
 *.zip
 *.vi
 *~
-*.sass-cache
 
 # OS or Editor folders
 .DS_Store
@@ -23,16 +27,16 @@ Thumbs.db
 nbproject
 *.sublime-project
 *.sublime-workspace
+.idea
 
 # Komodo
 *.komodoproject
 .komodotools
 
-# Folders to ignore
-.idea
-node_modules
-_site
-
 # grunt-html-validation
-validation-report.json
 validation-status.json
+validation-report.json
+
+# Folders to ignore
+node_modules
+bower_components


### PR DESCRIPTION
Can probably nuke the `_gh_pages` branch from both projects and just use `_site` though.
