### PR TITLE
Fix a typo in docs

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -21,7 +21,7 @@ title: Components &middot; Ratchet
 
 <div class="container">
   <!-- Components -->
-  <div class="docs-components column-group">  
+  <div class="docs-components column-group">
     <div class="device-column column units-2 lg-units-5 pull-right">
       <!-- In phone examples -->
       <div class="device js-device">
@@ -57,7 +57,7 @@ title: Components &middot; Ratchet
 
     <article class="component">
       <h3 class="component-title">Title bar with buttons</h3>
-      <p class="component-description">Buttons in a title bar are left or right aligned and should be used for actions. Use the <code>.pull-right</code> or <code>.pull-right</code> utility classes to float the buttons. Also, be sure to place any floated elements bofore the title.</p>
+      <p class="component-description">Buttons in a title bar are left or right aligned and should be used for actions. Use the <code>.pull-right</code> or <code>.pull-right</code> utility classes to float the buttons. Also, be sure to place any floated elements before the title.</p>
 
       <div class="component-example component-example-fullbleed">
         <header class="bar bar-nav">
@@ -1074,7 +1074,7 @@ document
     <h3 class="component-title">Popovers</h3>
 
 {% highlight html %}
-<div id="popover" class="popover">  
+<div id="popover" class="popover">
   <header class="bar bar-nav">
     <h1 class="title">Popover title</h1>
   </header>
@@ -1095,7 +1095,7 @@ document
 
 {% highlight html %}
 <header class="bar bar-nav">
-  <a href="#myPopover"> 
+  <a href="#myPopover">
     <h1 class="title">
       Tap title
       <span class="icon icon-caret"></span>
@@ -1105,7 +1105,7 @@ document
 {% endhighlight %}
 
   </article>
-  
+
   <!-- Modals -->
   <article class="component" id="modals">
     <h3 class="component-title">Modals</h3>
@@ -1117,7 +1117,7 @@ document
           <a class="icon icon-close pull-right" href="#myModalexample"></a>
           <h1 class="title">Modal mobile</h1>
         </header>
-        
+
         <p class="content-padded">The contents of my modal go here. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
       </div>
     </div>
@@ -1129,7 +1129,7 @@ document
     <a class="icon icon-close pull-right" href="#myModalexample"></a>
     <h1 class="title">Modal</h1>
   </header>
-  
+
   <div class="content">
     <p class="content-padded">The contents of my modal go here. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut.</p>
   </div>
@@ -1363,7 +1363,7 @@ window.addEventListener('push', myFunction);
 {% endhighlight %}
 
     </article>
-      
+
       <!-- Footer -->
       {% include footer.html %}
     </div>


### PR DESCRIPTION
Fixes a simple typo in the docs. Also, white space apparently.

Fixes #332.
