### PR TITLE
Download button spacing

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -276,7 +276,7 @@ body {
 }
 .docs-header-content .btn {
   display: block;
-  padding: 15px 89px 16px;
+  padding: 15px 90px 16px;
   font-size: 18px;
   margin-bottom: 0;
   color: #0a1855;

--- a/sass/docs.scss
+++ b/sass/docs.scss
@@ -280,7 +280,7 @@ body {
 
   .btn {
     display: block;
-    padding: 15px 89px 16px;
+    padding: 15px 90px 16px;
     font-size: 18px;
     margin-bottom: 0;
     color: #0a1855;


### PR DESCRIPTION
This branch makes the homepage download button the same width as the ad. Fixes #256.

![screen shot 2014-03-01 at 8 08 26 pm](https://f.cloud.github.com/assets/874145/2303477/6523549a-a1c0-11e3-87da-8add378e8b7b.png)
