### PR TITLE
Remove `bower_components` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ validation-report.json
 
 # Folders to ignore
 node_modules
-bower_components


### PR DESCRIPTION
`bower_components` can't appear as there are no any Bower dependencies.
