### PR TITLE
remove www. from twitter URL in template.html

### DIFF
--- a/dist/template.html
+++ b/dist/template.html
@@ -62,7 +62,7 @@
             </a>
           </li>
           <li class="table-view-cell">
-            <a class="navigate-right" href="https://www.twitter.com/GoRatchet">
+            <a class="navigate-right" href="https://twitter.com/GoRatchet">
               <strong>Ratchet on Twitter</strong>
             </a>
           </li>


### PR DESCRIPTION
No need for `www` in the twitter URL (will be removed anyway so will save a HTTP redirect).
