### PR TITLE
Support for CustomEvent on older devices.

### DIFF
--- a/js/push.js
+++ b/js/push.js
@@ -382,11 +382,19 @@
   };
 
   var triggerStateChange = function () {
-    var e = new CustomEvent('push', {
-      detail: { state: getCached(PUSH.id) },
-      bubbles: true,
-      cancelable: true
-    });
+    var e;
+    var options = {};
+    
+    options.detail = { state: getCached(PUSH.id) };
+    options.bubbles = true;
+    options.cancelable = true;
+    
+    if (typeof CustomEvent === 'function') {
+      e = new CustomEvent('push', options);
+    } else if (document.createEvent) {
+      e = document.createEvent('CustomEvent');
+      e.initCustomEvent('push', options.bubbles, options.cancelable, options.detail);
+    }
 
     window.dispatchEvent(e);
   };


### PR DESCRIPTION
Samsung Galaxy SII did not pass typeof CustomEvent == 'function' in a PhoneGap application. This broke Push and my app. This fix should be applied for all CustomEvents in Ratchet in order to work on older devices.
