### PR TITLE
Run `grunt`.

### DIFF
--- a/sass/normalize.scss
+++ b/sass/normalize.scss
@@ -1,4 +1,4 @@
-/*! normalize.css v3.0.0 | MIT License | git.io/normalize */
+/*!! normalize.css v3.0.0 | MIT License | git.io/normalize */
 
 // 1. Set default font family to sans-serif.
 // 2. Prevent iOS text size adjust after orientation change, without disabling


### PR DESCRIPTION
/CC @connors 

I get these changes; must be due to the Sass update. Thought I'd make a PR to confirm those weren't any workarounds or something.

Basically, `rgba(0, 0, 0, 0)` -> `transparent`.

If you agree with this, we should make the changes to the scss files too.
