### PR TITLE
Animated transition on `window.history.back()`

### DIFF
--- a/js/push.js
+++ b/js/push.js
@@ -22,9 +22,10 @@
   var maxCacheLength = 20;
   var cacheMapping   = sessionStorage;
   var domCache       = {};
+  // Change these to unquoted camelcase in the next major version bump
   var transitionMap  = {
-    slideIn  : 'slide-out',
-    slideOut : 'slide-in',
+    'slide-in'  : 'slide-out',
+    'slide-out' : 'slide-in',
     fade     : 'fade'
   };
 
@@ -239,7 +240,7 @@
         url        : window.location.href,
         title      : document.title,
         timeout    : options.timeout,
-        transition : null
+        transition : options.transition
       });
     }
 


### PR DESCRIPTION
~~Animated back transitions are working when using push.js via data attributes (apparently, though I never checked). This pr makes it so that they also work when using push.js via PUSH() function in javascript.~~

Animated back transitions don't work at all. Demo (enable touch emulation in devtools):
http://push-js-test.s3.amazonaws.com/test.html

This pr fixes it.
