### PR TITLE
push.js: cache dom before leaving the page, rather than right after loading it

### DIFF
--- a/js/push.js
+++ b/js/push.js
@@ -42,7 +42,6 @@
     }
     cacheMapping[data.id] = JSON.stringify(data);
     window.history.replaceState(data.id, data.title, data.url);
-    domCache[data.id] = document.body.cloneNode(true);
   };
 
   var cachePush = function () {
@@ -60,7 +59,7 @@
       delete cacheMapping[cacheBackStack.shift()];
     }
 
-    window.history.pushState(null, '', cacheMapping[PUSH.id].url);
+    window.history.pushState(null, '', getCached(PUSH.id).url);
 
     cacheMapping.cacheForwardStack = JSON.stringify(cacheForwardStack);
     cacheMapping.cacheBackStack    = JSON.stringify(cacheBackStack);
@@ -243,6 +242,8 @@
       });
     }
 
+    cacheCurrentContent();
+
     if (options.timeout) {
       options._timeout = setTimeout(function () {  xhr.abort('timeout'); }, options.timeout);
     }
@@ -253,6 +254,10 @@
       cachePush();
     }
   };
+
+  function cacheCurrentContent() {
+    domCache[PUSH.id] = document.body.cloneNode(true);
+  }
 
 
   // Main XHR handlers


### PR DESCRIPTION
This way dynamically added dom (vis js) also gets cached. So that `history.back()` shows the page exactly the way it was right before user left it.
