### PR TITLE
Update sliders.js

### DIFF
--- a/js/sliders.js
+++ b/js/sliders.js
@@ -120,7 +120,7 @@
       return;
     }
 
-    // were done moving
+    // we're done moving
     startedMoving = false;
 
     setSlideNumber(


### PR DESCRIPTION
This update get's rid of the jump at the start of the slide. On almost every slider know to man there is a 15px jump. This one has it to. If you log out deltaX you'll see it almost always starts with -16px. That's a noticeable jump. This change fixes it so that the slide starts from 0 and smoothly goes from there.
