### PR TITLE
Allow non-slides in the .slide-group.

### DIFF
--- a/js/sliders.js
+++ b/js/sliders.js
@@ -47,10 +47,10 @@
 
   var setSlideNumber = function (offset) {
     var round = offset ? (deltaX < 0 ? 'ceil' : 'floor') : 'round';
-    slideNumber = Math[round](getScroll() / (scrollableArea / slider.children.length));
+    slideNumber = Math[round](getScroll() / (scrollableArea / slider.querySelectorAll('.slide').length));
     slideNumber += offset;
     slideNumber = Math.min(slideNumber, 0);
-    slideNumber = Math.max(-(slider.children.length - 1), slideNumber);
+    slideNumber = Math.max(-(slider.querySelectorAll('.slide').length - 1), slideNumber);
   };
 
   var onTouchStart = function (e) {
@@ -62,11 +62,11 @@
 
     var firstItem  = slider.querySelector('.slide');
 
-    scrollableArea = firstItem.offsetWidth * slider.children.length;
+    scrollableArea = firstItem.offsetWidth * slider.querySelectorAll('.slide').length;
     isScrolling    = undefined;
     sliderWidth    = slider.offsetWidth;
     resistance     = 1;
-    lastSlide      = -(slider.children.length - 1);
+    lastSlide      = -(slider.querySelectorAll('.slide').length - 1);
     startTime      = +new Date();
     pageX          = e.touches[0].pageX;
     pageY          = e.touches[0].pageY;


### PR DESCRIPTION
The way the slider works right now is that it counts the children of the `.slide-group` even if those children are not `.slide` this include elements without size like `<script>`. This is incompatible with emberjs that injects script tags into the DOM to keep track of data binding. So if you do something like this:

```
<div class="slider">
    <div class="slide-group">
        {{#each}}
            <div class="slide">{{this}}</div>
        {{/each}}
    </div>
</div>
```

The DOM will look something like:

```
<div class="slider">
    <div class="slide-group">
        <script id="metamorph-11-start" type="text/x-placeholder"></script><script id="metamorph-14-start" type="text/x-placeholder"></script>
        <div class="slide">foo</div>
        <script id="metamorph-14-end" type="text/x-placeholder"></script><script id="metamorph-11-end" type="text/x-placeholder"></script>
    </div>
</div>
```

And the slider will think there's 3 slides.
