### PR TITLE
modalToggle.hash add check contains slash

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -24,7 +24,7 @@
 
   var getModal = function (event) {
     var modalToggle = findModals(event.target);
-    if (modalToggle && modalToggle.hash) {
+    if (modalToggle && modalToggle.hash && modalToggle.hash.indexOf('/') < 0) {
       return document.querySelector(modalToggle.hash);
     }
   };


### PR DESCRIPTION
modals.js add slash check, otherwise they will perform error 
