### PR TITLE
Fix push.js transition ending listener for Firefox

### DIFF
--- a/dist/js/ratchet.js
+++ b/dist/js/ratchet.js
@@ -491,23 +491,28 @@
       container.classList.remove('in');
       var fadeContainerEnd = function () {
         container.removeEventListener('webkitTransitionEnd', fadeContainerEnd);
+        container.removeEventListener('transitionend', fadeContainerEnd);
         swap.classList.add('in');
         swap.addEventListener('webkitTransitionEnd', fadeSwapEnd);
+        swap.addEventListener('transitionend', fadeSwapEnd);
       };
       var fadeSwapEnd = function () {
         swap.removeEventListener('webkitTransitionEnd', fadeSwapEnd);
+        swap.removeEventListener('transitionend', fadeSwapEnd);
         container.parentNode.removeChild(container);
         swap.classList.remove('fade');
         swap.classList.remove('in');
         complete && complete();
       };
       container.addEventListener('webkitTransitionEnd', fadeContainerEnd);
+      container.addEventListener('transitionend', fadeContainerEnd);
 
     }
 
     if (/slide/.test(transition)) {
       var slideEnd = function () {
         swap.removeEventListener('webkitTransitionEnd', slideEnd);
+        swap.removeEventListener('transitionend', slideEnd);
         swap.classList.remove('sliding', 'sliding-in');
         swap.classList.remove(swapDirection);
         container.parentNode.removeChild(container);
@@ -520,6 +525,7 @@
       container.classList.add(containerDirection);
       swap.classList.remove(swapDirection);
       swap.addEventListener('webkitTransitionEnd', slideEnd);
+      swap.addEventListener('transitionend', slideEnd);
     }
   };
 

--- a/js/push.js
+++ b/js/push.js
@@ -352,23 +352,28 @@
       container.classList.remove('in');
       var fadeContainerEnd = function () {
         container.removeEventListener('webkitTransitionEnd', fadeContainerEnd);
+        container.removeEventListener('transitionend', fadeContainerEnd);
         swap.classList.add('in');
         swap.addEventListener('webkitTransitionEnd', fadeSwapEnd);
+        swap.addEventListener('transitionend', fadeSwapEnd);'s'
       };
       var fadeSwapEnd = function () {
         swap.removeEventListener('webkitTransitionEnd', fadeSwapEnd);
+        swap.removeEventListener('transitionend', fadeSwapEnd);
         container.parentNode.removeChild(container);
         swap.classList.remove('fade');
         swap.classList.remove('in');
         complete && complete();
       };
       container.addEventListener('webkitTransitionEnd', fadeContainerEnd);
+      container.addEventListener('transitionend', fadeContainerEnd);
 
     }
 
     if (/slide/.test(transition)) {
       var slideEnd = function () {
         swap.removeEventListener('webkitTransitionEnd', slideEnd);
+        swap.removeEventListener('transitionend', slideEnd);
         swap.classList.remove('sliding', 'sliding-in');
         swap.classList.remove(swapDirection);
         container.parentNode.removeChild(container);
@@ -381,6 +386,7 @@
       container.classList.add(containerDirection);
       swap.classList.remove(swapDirection);
       swap.addEventListener('webkitTransitionEnd', slideEnd);
+      swap.addEventListener('transitionend', slideEnd);
     }
   };
 

--- a/js/push.js
+++ b/js/push.js
@@ -355,7 +355,7 @@
         container.removeEventListener('transitionend', fadeContainerEnd);
         swap.classList.add('in');
         swap.addEventListener('webkitTransitionEnd', fadeSwapEnd);
-        swap.addEventListener('transitionend', fadeSwapEnd);'s'
+        swap.addEventListener('transitionend', fadeSwapEnd);
       };
       var fadeSwapEnd = function () {
         swap.removeEventListener('webkitTransitionEnd', fadeSwapEnd);


### PR DESCRIPTION
Firefox fire the event "transitionend"

https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Using_CSS_transitions#Detecting_the_completion_of_a_transition