### PR TITLE
Fixes validate html to allow using multiple h1 tags

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,7 +222,8 @@ module.exports = function(grunt) {
         reset: true,
         relaxerror: [
           'Attribute ontouchstart not allowed on element body at this point.',
-          'Bad value X-UA-Compatible for attribute http-equiv on element meta.'
+          'Bad value X-UA-Compatible for attribute http-equiv on element meta.',
+          'Consider using the h1 element as a top-level heading only \\(all h1 elements are treated as top-level headings by many screen readers and other tools\\)\\.'
         ]
       },
       files: {


### PR DESCRIPTION
I added relaxerror rule to allow using multiple h1 tags for fixing npm test:

```
Running "validation:files" (validation) task
Validation started for.. _site/about/index.html
>> Validation successful..
Validation started for.. _site/components/index.html
>> Validation successful..
Validation started for.. _site/examples/app-android-notes/index.html
>> Validation successful..
Validation started for.. _site/examples/app-ios-mail/inbox.html
>> Validation successful..
Validation started for.. _site/examples/app-ios-mail/index.html
>> Validation successful..
Validation started for.. _site/examples/app-movies/choose-theater.html
>> Validation successful..
Validation started for.. _site/examples/app-movies/index.html
>> Validation successful..
Validation started for.. _site/examples/index.html
>> Validation successful..
Validation started for.. _site/getting-started/index.html
>> Validation successful..
Validation started for.. _site/index.html
>> Validation successful..
Validation started for.. _site/one.html
>> Validation successful..
Validation started for.. _site/template.html
>> Validation successful..
Validation started for.. _site/two.html
>> Validation successful..
Validation report generated: validation-report.json

Done, without errors.
```
