### PR TITLE
Click handler for non-touch devices

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -28,14 +28,18 @@
       return document.querySelector(modalToggle.hash);
     }
   };
-
-  window.addEventListener('touchend', function (event) {
+    
+    var openModal = function (event) {
     var modal = getModal(event);
     if (modal) {
       if (modal && modal.classList.contains('modal')) {
         modal.classList.toggle('active');
       }
+        $(window).trigger("modalOpened",  {smth:modal});
       event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
     }
-  });
-}());
+  };
+    //Added click for desktop compatibility
+    window.addEventListener('click', openModal);
+    window.addEventListener('touchend', openModal);
+})();


### PR DESCRIPTION
Added click handler for non-touch devices compatibility.
To the issue: https://github.com/twbs/ratchet/issues/569
Reduced test case: http://goratchet.com/components/#modals
If using <a> tag without a "btn" class, then modal will not be opened on non-touch devices.