### PR TITLE
Split border-width into separate variable

### DIFF
--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -54,5 +54,6 @@ $timing-fuction: cubic-bezier(.1,.5,.1,1) !default; // Inspired by @c2prods
 // Borders
 // --------------------------------------------------
 
-$border-default: 1px solid #ddd !default;
+$border-default-width: 1px;
+$border-default: $border-default-width solid #ddd;
 $border-radius: 6px !default;


### PR DESCRIPTION
In order to override some content spacing based upon header/footer bars, it was necessary to take border-width into account during other sass calculations.  Splitting it into a variable improves readability instead of having code like:

```
.content {
    margin-bottom: ($bar-base-height + ($bar-side-spacing + 1) * 2);  // adding 1 for $border-default's border-width
}
```

I can now use code like:

```
.content {
    margin-bottom: ($bar-base-height + ($bar-side-spacing + $border-default-width) * 2);
}
```
