### PR TITLE
Fixing fade animation missing its transition

### DIFF
--- a/sass/push.scss
+++ b/sass/push.scss
@@ -7,6 +7,7 @@
   &.fade {
     left: 0;
     opacity: 0;
+    @include transition(opacity .4s);
 
     &.in {
       opacity: 1;


### PR DESCRIPTION
The push-event will not be fired unless a transition is present

tested in:
FF 33.0.2 (Desktop)
FF 33.0 (Android 4.4.4)
Chrome 38.0.2125.114 (Android 4.4.4)
Android browser 4.4.4-158ac76b02