### PR TITLE
Add configurable ratchicons directory.

### DIFF
--- a/sass/ratchicons.scss
+++ b/sass/ratchicons.scss
@@ -6,11 +6,11 @@
   font-family: Ratchicons;
   font-weight: normal;
   font-style: normal;
-  src: url($font-directory + '/ratchicons.eot');
-  src: url($font-directory + '/ratchicons.eot?#iefix') format('embedded-opentype'),
-       url($font-directory + '/ratchicons.woff') format('woff'),
-       url($font-directory + '/ratchicons.ttf') format('truetype'),
-       url($font-directory + '/ratchicons.svg#svgFontName') format('svg');
+  src: url($ratchicons-directory + '/ratchicons.eot');
+  src: url($ratchicons-directory + '/ratchicons.eot?#iefix') format('embedded-opentype'),
+       url($ratchicons-directory + '/ratchicons.woff') format('woff'),
+       url($ratchicons-directory + '/ratchicons.ttf') format('truetype'),
+       url($ratchicons-directory + '/ratchicons.svg#svgFontName') format('svg');
 }
 
 .icon {

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -5,12 +5,12 @@
 
 // Type
 // --------------------------------------------------
-$font-directory: "../fonts" !default;
 $font-family-default: "Helvetica Neue", Helvetica, sans-serif !default;
 $font-size-default: 17px !default;
 $font-weight: 500 !default;
 $font-weight-light: 400 !default;
 $line-height-default: 21px !default;
+$ratchicons-directory: "../fonts" !default;
 
 
 // Colors


### PR DESCRIPTION
This is the PR for issue [#711](https://github.com/twbs/ratchet/issues/711).

As it states there, we found our setup was trying to retrieve the ratchicons from `/assets/fonts/...` rather than at `/assets/ratchet/fonts/..` where they are actually located.

I've added a configurable sass variable so that the directory can be changed if need be.
