### PR TITLE
Added ability to toggle the Popover

### DIFF
--- a/js/popovers.js
+++ b/js/popovers.js
@@ -40,22 +40,21 @@
     var element = document.createElement('div');
 
     element.classList.add('backdrop');
-
     element.addEventListener('touchend', hidePopover);
     element.addEventListener('click', hidePopover);
 
     return element;
   }());
 
-  var getPopover = function (e) {
-    var anchor = findPopovers(e.target);
+  var getPopover = function (e, id) {
+    var anchor = e && findPopovers(e.target);
 
-    if (!anchor || !anchor.hash || (anchor.hash.indexOf('/') > 0)) {
+    if ((!anchor || !anchor.hash || (anchor.hash.indexOf('/') > 0)) && !id) {
       return;
     }
 
     try {
-      popover = document.querySelector(anchor.hash);
+      popover = document.querySelector(id || anchor.hash);
     }
     catch (error) {
       popover = null;
@@ -72,8 +71,8 @@
     return popover;
   };
 
-  var showHidePopover = function (e) {
-    var popover = getPopover(e);
+  var showHidePopover = function (e, id) {
+    var popover = getPopover(e, id);
 
     if (!popover || !!listener) {
       return;
@@ -92,5 +91,12 @@
 
   window.addEventListener('touchend', showHidePopover);
   window.addEventListener('click', showHidePopover);
-
+  window.POPOVER = {
+    show: function (id) {
+      showHidePopover(null, id);
+    },
+    hide: function () {
+      popover && hidePopover();
+    }
+  };
 }());


### PR DESCRIPTION
Added the ability to toggle the popover by clicking/touching the link used to invoke it, a second time.  This is useful for the case where a custom popover implementation doesn't leave much backdrop to click, hiding the popover...or when it is too far to travel for a click/touch.  Added mouse click handlers for showing/hiding to facilitate web use-cases, and simple rapid-click protection that could cause the popover to get "stuck" open, without the ability to close.
