### PR TITLE
[Feature #690] Create modalOpen and modalClose events 

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -9,6 +9,14 @@
 !(function () {
   'use strict';
 
+  var eventModalOpen = new CustomEvent('modalOpen', {
+    bubbles: true,
+    cancelable: true
+  });
+  var eventModalClose = new CustomEvent('modalClose', {
+    bubbles: true,
+    cancelable: true
+  });
   var findModals = function (target) {
     var i;
     var modals = document.querySelectorAll('a');
@@ -31,11 +39,14 @@
 
   window.addEventListener('touchend', function (event) {
     var modal = getModal(event);
-    if (modal) {
-      if (modal && modal.classList.contains('modal')) {
-        modal.classList.toggle('active');
+    if (modal && modal.classList.contains('modal')) {
+      var eventToDispatch = eventModalOpen;
+      if (modal.classList.contains('active')) {
+        eventToDispatch = eventModalClose;
       }
-      event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
+      modal.dispatchEvent(eventToDispatch);
+      modal.classList.toggle('active');
     }
+    event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
   });
 }());


### PR DESCRIPTION
Hi,

I've created two events when modal is opened or closed.
Now we can do this to listen those events:

```js
$('#myModalexample').on('modalOpen', function(e) {
    console.log('open');
});
$('#myModalexample').on('modalClose', function(e) {
    console.log('close');
});
```

Fixes #690.