### PR TITLE
use current page's <title> if XHR response does not contain one

### DIFF
--- a/js/push.js
+++ b/js/push.js
@@ -464,7 +464,7 @@
       head.innerHTML = responseText;
     }
 
-    data.title = head.querySelector('title') ? head.querySelector('title') : document.querySelector('title');
+    data.title = head.querySelector('title') || document.querySelector('title');
     var text = 'innerText' in data.title ? 'innerText' : 'textContent';
     data.title = data.title && data.title[text].trim();
 

--- a/js/push.js
+++ b/js/push.js
@@ -464,7 +464,7 @@
       head.innerHTML = responseText;
     }
 
-    data.title = head.querySelector('title');
+    data.title = head.querySelector('title') ? head.querySelector('title') : document.querySelector('title');
     var text = 'innerText' in data.title ? 'innerText' : 'textContent';
     data.title = data.title && data.title[text].trim();
 


### PR DESCRIPTION
May be useful to default to current page's `<title>` if there is no `<title>` in the response.  If its not sent, `data.title` will be `null` and the next line will fail. I also think the docs can be a little more clear about what needs to be sent, I'll make another patch for that after this is approved/denied.