### PR TITLE
Js refactor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,7 @@ module.exports = function (grunt) {
           banner: '<%= banner %>'
         },
         src: [
+          'js/common.js',
           'js/modals.js',
           'js/popovers.js',
           'js/push.js',

--- a/js/common.js
+++ b/js/common.js
@@ -9,8 +9,13 @@
 !(function () {
   'use strict';
 
+  // Create Ratchet namespace
+  if (typeof window.RATCHET === 'undefined') {
+    window.RATCHET = {};
+  }
+
   // Original script from http://davidwalsh.name/vendor-prefix
-  var getBrowserCapabilities = (function () {
+  window.RATCHET.getBrowserCapabilities = (function () {
     var styles = window.getComputedStyle(document.documentElement, '');
     var pre = (Array.prototype.slice
         .call(styles)
@@ -22,6 +27,4 @@
       transform: pre[0].toUpperCase() + pre.substr(1) + 'Transform'
     };
   })();
-
-  window.getBrowserCapabilities = getBrowserCapabilities;
 }());

--- a/js/common.js
+++ b/js/common.js
@@ -1,0 +1,27 @@
+/* ========================================================================
+ * Ratchet: common.js v2.0.2
+ * http://goratchet.com/
+ * ========================================================================
+ * Copyright 2015 Connor Sears
+ * Licensed under MIT (https://github.com/twbs/ratchet/blob/master/LICENSE)
+ * ======================================================================== */
+
+!(function () {
+  'use strict';
+
+  // Original script from http://davidwalsh.name/vendor-prefix
+  var getBrowserCapabilities = (function () {
+    var styles = window.getComputedStyle(document.documentElement, '');
+    var pre = (Array.prototype.slice
+        .call(styles)
+        .join('')
+        .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
+      )[1];
+    return {
+      prefix: '-' + pre + '-',
+      transform: pre[0].toUpperCase() + pre.substr(1) + 'Transform'
+    };
+  })();
+
+  window.getBrowserCapabilities = getBrowserCapabilities;
+}());

--- a/js/push.js
+++ b/js/push.js
@@ -502,6 +502,9 @@
     }
   });
   window.addEventListener('popstate', popstate);
+
+  // TODO : Remove this line in the next major version
   window.PUSH = PUSH;
+  window.RATCHET.push = PUSH;
 
 }());

--- a/js/sliders.js
+++ b/js/sliders.js
@@ -25,8 +25,8 @@
   var scrollableArea;
   var startedMoving;
 
-  var transformPrefix   = window.getBrowserCapabilities.prefix;
-  var transformProperty = window.getBrowserCapabilities.transform;
+  var transformPrefix   = window.RATCHET.getBrowserCapabilities.prefix;
+  var transformProperty = window.RATCHET.getBrowserCapabilities.transform;
 
   var getSlider = function (target) {
     var i;

--- a/js/sliders.js
+++ b/js/sliders.js
@@ -25,22 +25,8 @@
   var scrollableArea;
   var startedMoving;
 
-  // Original script from http://davidwalsh.name/vendor-prefix
-  var getBrowserCapabilities = (function () {
-    var styles = window.getComputedStyle(document.documentElement, '');
-    var pre = (Array.prototype.slice
-        .call(styles)
-        .join('')
-        .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
-      )[1];
-    return {
-      prefix: '-' + pre + '-',
-      transform: pre[0].toUpperCase() + pre.substr(1) + 'Transform'
-    };
-  })();
-
-  var transformPrefix   = getBrowserCapabilities.prefix;
-  var transformProperty = getBrowserCapabilities.transform;
+  var transformPrefix   = window.getBrowserCapabilities.prefix;
+  var transformProperty = window.getBrowserCapabilities.transform;
 
   var getSlider = function (target) {
     var i;

--- a/js/toggles.js
+++ b/js/toggles.js
@@ -14,21 +14,7 @@
   var touchMove = false;
   var distanceX = false;
   var toggle    = false;
-
-  // Original script from http://davidwalsh.name/vendor-prefix
-  var getBrowserCapabilities = (function () {
-    var styles = window.getComputedStyle(document.documentElement, '');
-    var pre = (Array.prototype.slice
-        .call(styles)
-        .join('')
-        .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
-      )[1];
-    return {
-      transform: pre[0].toUpperCase() + pre.substr(1) + 'Transform'
-    };
-  })();
-
-  var transformProperty = getBrowserCapabilities.transform;
+  var transformProperty = window.getBrowserCapabilities.transform;
 
   var findToggle = function (target) {
     var i;

--- a/js/toggles.js
+++ b/js/toggles.js
@@ -14,7 +14,7 @@
   var touchMove = false;
   var distanceX = false;
   var toggle    = false;
-  var transformProperty = window.getBrowserCapabilities.transform;
+  var transformProperty = window.RATCHET.getBrowserCapabilities.transform;
 
   var findToggle = function (target) {
     var i;


### PR DESCRIPTION
Hello,

I created a common.js file to refactor some commons function.
We have talked about it with @XhmikosR in #491.

I added `getBrowserCapabilities` to `window` object, but i think it would be better if Ratchet had a namespace for example: **`rtc`**

And with that we will be able to do that:

```js
window.rtc.getBrowserCapabilities = getBrowserCapabilities;
```
or

```js
window.rtc.push = PUSH;
```