### PR TITLE
Change deprecated gem params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - travis_retry npm install -g grunt-cli
   - travis_retry npm install
-  - travis_retry gem install --no-ri --no-rdoc "jekyll:~>2.5.3" "rouge:~>1.8" "sass:~>3.4"
+  - travis_retry gem install --no-document "jekyll:~>2.5.3" "rouge:~>1.8" "sass:~>3.4"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
http://guides.rubygems.org/command-reference/#deprecated-options-1

Or `gem install --help` (Deprecated Options)