### PR TITLE
Only preventing touchend events for modals (Fix #768 / #779)

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -46,7 +46,7 @@
       }
       modal.dispatchEvent(eventToDispatch);
       modal.classList.toggle('active');
+      event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
     }
-    event.preventDefault(); // prevents rewriting url (apps can still use hash values in url)
   });
 }());


### PR DESCRIPTION
Fixes #768, Fixes #779

Touchend event was always prevented instead of only when we are in a modal.