### PR TITLE
Fix popover link to match the correct ID

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -1092,7 +1092,7 @@ document
 
 {% highlight html %}
 <header class="bar bar-nav">
-  <a href="#myPopover">
+  <a href="#popover">
     <h1 class="title">
       Tap title
       <span class="icon icon-caret"></span>


### PR DESCRIPTION
The popover doesn't work unless the ID matches.