### PR TITLE
Add a jQuery CDN fallback

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -41,5 +41,6 @@
 </script>
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="//code.jquery.com/jquery-1.12.2.min.js"><\/script>')</script>
 <script src="/dist/js/ratchet.min.js"></script>
 <script src="/assets/js/docs.min.js"></script>


### PR DESCRIPTION
Add a CDN fallback for jQuery. Useful for a variety of reasons, including providing a working fallback for users in China where Google's CDN is reportedly blocked.
