### PR TITLE
Always load Google Font over HTTPS

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -9,7 +9,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
 <!-- Google Web Fonts -->
-<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,500,700%7COpen+Sans:400,300">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700%7COpen+Sans:400,300">
 
 <link rel="stylesheet" href="/dist/css/ratchet.min.css">
 <link rel="stylesheet" href="/assets/css/docs.min.css">


### PR DESCRIPTION
Always load Google Font over HTTPS as recommended by Google (bonus: will also mean it'll display during local development)
