### PR TITLE
Fixed "active" class bug with toggle within a segmented control body

### DIFF
--- a/js/segmented-controllers.js
+++ b/js/segmented-controllers.js
@@ -28,13 +28,14 @@
     var targetBody;
     var targetTab     = getTarget(e.target);
     var className     = 'active';
-    var classSelector = '.' + className;
+    var classSelector = '.control-content.' + className;
+    var tabClassSelector = '.control-item.' + className;
 
     if (!targetTab) {
       return;
     }
 
-    activeTab = targetTab.parentNode.querySelector(classSelector);
+    activeTab = targetTab.parentNode.querySelector(tabClassSelector);
 
     if (activeTab) {
       activeTab.classList.remove(className);

--- a/js/segmented-controllers.js
+++ b/js/segmented-controllers.js
@@ -7,64 +7,61 @@
  * ======================================================================== */
 
 !(function () {
-  'use strict';
+    'use strict';
 
-  var getTarget = function (target) {
-    var i;
-    var segmentedControls = document.querySelectorAll('.segmented-control .control-item');
+    var getTarget = function (target) {
+        var i;
+        var segmentedControls = document.querySelectorAll('.segmented-control .control-item');
 
-    for (; target && target !== document; target = target.parentNode) {
-      for (i = segmentedControls.length; i--;) {
-        if (segmentedControls[i] === target) {
-          return target;
+        for (; target && target !== document; target = target.parentNode) {
+            for (i = segmentedControls.length; i--;) {
+                if (segmentedControls[i] === target) {
+                    return target;
+                }
+            }
         }
-      }
-    }
-  };
+    };
+    var tabTouchEnd = function (e) {
+        var activeTab;
+        var activeBodies;
+        var targetBody;
+        var targetTab = getTarget(e.target);
+        var className = 'active';
+        var classSelector = '.control-content.active';
+        var tabClassSelector = '.control-item.active';
 
-  window.addEventListener('touchend', function (e) {
-    var activeTab;
-    var activeBodies;
-    var targetBody;
-    var targetTab     = getTarget(e.target);
-    var className     = 'active';
-    var classSelector = '.' + className;
+        if (!targetTab) {
+            return;
+        }
 
-    if (!targetTab) {
-      return;
-    }
+        activeTab = targetTab.parentNode.querySelector(tabClassSelector);
 
-    activeTab = targetTab.parentNode.querySelector(classSelector);
+        if (activeTab) {
+            activeTab.classList.remove(className);
+        }
 
-    if (activeTab) {
-      activeTab.classList.remove(className);
-    }
+        targetTab.classList.add(className);
 
-    targetTab.classList.add(className);
+        if (!targetTab.hash) {
+            return;
+        }
 
-    if (!targetTab.hash) {
-      return;
-    }
+        targetBody = document.querySelector(targetTab.hash);
 
-    targetBody = document.querySelector(targetTab.hash);
+        if (!targetBody) {
+            return;
+        }
 
-    if (!targetBody) {
-      return;
-    }
+        activeBodies = targetBody.parentNode.querySelectorAll(classSelector);
 
-    activeBodies = targetBody.parentNode.querySelectorAll(classSelector);
+        for (var i = 0; i < activeBodies.length; i++) {
+            activeBodies[i].classList.remove(className);
+        }
 
-    for (var i = 0; i < activeBodies.length; i++) {
-      activeBodies[i].classList.remove(className);
-    }
+        targetBody.classList.add(className);
+    };
+    window.addEventListener('touchend', tabTouchEnd);
+    window.addEventListener("MSPointerUp", tabTouchEnd);
 
-    targetBody.classList.add(className);
-  });
-
-  window.addEventListener('click', function (e) {
-    if (getTarget(e.target)) {
-      e.preventDefault();
-    }
-  });
-
+    window.addEventListener('click', function (e) { if (getTarget(e.target)) { preventDef(e); } });
 }());

--- a/js/segmented-controllers.js
+++ b/js/segmented-controllers.js
@@ -7,61 +7,64 @@
  * ======================================================================== */
 
 !(function () {
-    'use strict';
+  'use strict';
 
-    var getTarget = function (target) {
-        var i;
-        var segmentedControls = document.querySelectorAll('.segmented-control .control-item');
+  var getTarget = function (target) {
+    var i;
+    var segmentedControls = document.querySelectorAll('.segmented-control .control-item');
 
-        for (; target && target !== document; target = target.parentNode) {
-            for (i = segmentedControls.length; i--;) {
-                if (segmentedControls[i] === target) {
-                    return target;
-                }
-            }
+    for (; target && target !== document; target = target.parentNode) {
+      for (i = segmentedControls.length; i--;) {
+        if (segmentedControls[i] === target) {
+          return target;
         }
-    };
-    var tabTouchEnd = function (e) {
-        var activeTab;
-        var activeBodies;
-        var targetBody;
-        var targetTab = getTarget(e.target);
-        var className = 'active';
-        var classSelector = '.control-content.active';
-        var tabClassSelector = '.control-item.active';
+      }
+    }
+  };
 
-        if (!targetTab) {
-            return;
-        }
+  window.addEventListener('touchend', function (e) {
+    var activeTab;
+    var activeBodies;
+    var targetBody;
+    var targetTab     = getTarget(e.target);
+    var className     = 'active';
+    var classSelector = '.' + className;
 
-        activeTab = targetTab.parentNode.querySelector(tabClassSelector);
+    if (!targetTab) {
+      return;
+    }
 
-        if (activeTab) {
-            activeTab.classList.remove(className);
-        }
+    activeTab = targetTab.parentNode.querySelector(classSelector);
 
-        targetTab.classList.add(className);
+    if (activeTab) {
+      activeTab.classList.remove(className);
+    }
 
-        if (!targetTab.hash) {
-            return;
-        }
+    targetTab.classList.add(className);
 
-        targetBody = document.querySelector(targetTab.hash);
+    if (!targetTab.hash) {
+      return;
+    }
 
-        if (!targetBody) {
-            return;
-        }
+    targetBody = document.querySelector(targetTab.hash);
 
-        activeBodies = targetBody.parentNode.querySelectorAll(classSelector);
+    if (!targetBody) {
+      return;
+    }
 
-        for (var i = 0; i < activeBodies.length; i++) {
-            activeBodies[i].classList.remove(className);
-        }
+    activeBodies = targetBody.parentNode.querySelectorAll(classSelector);
 
-        targetBody.classList.add(className);
-    };
-    window.addEventListener('touchend', tabTouchEnd);
-    window.addEventListener("MSPointerUp", tabTouchEnd);
+    for (var i = 0; i < activeBodies.length; i++) {
+      activeBodies[i].classList.remove(className);
+    }
 
-    window.addEventListener('click', function (e) { if (getTarget(e.target)) { preventDef(e); } });
+    targetBody.classList.add(className);
+  });
+
+  window.addEventListener('click', function (e) {
+    if (getTarget(e.target)) {
+      e.preventDefault();
+    }
+  });
+
 }());


### PR DESCRIPTION
I had originally made a pull request and completely screwed up the commit. Hopefully this is much clearer. It's a simple fix that more precisely specifies the CSS class in the queryselectors to prevent altering any other "active" CSS classes that may exist as child nodes, mainly the toggle switches.
