### PR TITLE
Added Support to disable the toggle

### DIFF
--- a/dist/js/ratchet.js
+++ b/dist/js/ratchet.js
@@ -989,6 +989,9 @@
     if (!toggle) {
       return;
     }
+    if(toggle.classList.contains('disabled')) {
+      return;
+    }
 
     var handle      = toggle.querySelector('.toggle-handle');
     var toggleWidth = toggle.clientWidth;
@@ -1007,6 +1010,9 @@
     }
 
     if (!toggle) {
+      return;
+    }
+    if(toggle.classList.contains('disabled')) {
       return;
     }
 
@@ -1039,6 +1045,9 @@
 
   window.addEventListener('touchend', function (e) {
     if (!toggle) {
+      return;
+    }
+    if(toggle.classList.contains('disabled')) {
       return;
     }
 

--- a/js/toggles.js
+++ b/js/toggles.js
@@ -37,6 +37,9 @@
     if (!toggle) {
       return;
     }
+    if(toggle.classList.contains('disabled')) {
+      return;
+    }
 
     var handle      = toggle.querySelector('.toggle-handle');
     var toggleWidth = toggle.clientWidth;
@@ -55,6 +58,9 @@
     }
 
     if (!toggle) {
+      return;
+    }
+    if(toggle.classList.contains('disabled')) {
       return;
     }
 
@@ -87,6 +93,9 @@
 
   window.addEventListener('touchend', function (e) {
     if (!toggle) {
+      return;
+    }
+    if(toggle.classList.contains('disabled')) {
       return;
     }
 


### PR DESCRIPTION
`if(toggle.classList.contains('disabled')) {
      return;
}`

Adding the above code to toggle's `touchstart`, `touchmove` and `touchend` event listener helps to disable the toggle.

I have not created the minified file nor created the source map file.
