### PR TITLE
Remove Google Analytics

### DIFF
--- a/dist/js/ratchet.js
+++ b/dist/js/ratchet.js
@@ -215,8 +215,6 @@
  * Licensed under MIT (https://github.com/twbs/ratchet/blob/master/LICENSE)
  * ======================================================================== */
 
-/* global _gaq: true */
-
 !(function () {
   'use strict';
 
@@ -531,9 +529,6 @@
       triggerStateChange();
     });
 
-    if (!options.ignorePush && window._gaq) {
-      _gaq.push(['_trackPageview']); // google analytics
-    }
     if (!options.hash) {
       return;
     }

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -15,12 +15,3 @@
 <link rel="stylesheet" href="/assets/css/docs.min.css">
 
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/img/apple-touch-icon-114x114.png">
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-36050008-1', 'goratchet.com');
-  ga('send', 'pageview');
-</script>

--- a/docs/dist/js/ratchet.js
+++ b/docs/dist/js/ratchet.js
@@ -215,8 +215,6 @@
  * Licensed under MIT (https://github.com/twbs/ratchet/blob/master/LICENSE)
  * ======================================================================== */
 
-/* global _gaq: true */
-
 !(function () {
   'use strict';
 
@@ -531,9 +529,6 @@
       triggerStateChange();
     });
 
-    if (!options.ignorePush && window._gaq) {
-      _gaq.push(['_trackPageview']); // google analytics
-    }
     if (!options.hash) {
       return;
     }

--- a/js/push.js
+++ b/js/push.js
@@ -7,8 +7,6 @@
  * Licensed under MIT (https://github.com/twbs/ratchet/blob/master/LICENSE)
  * ======================================================================== */
 
-/* global _gaq: true */
-
 !(function () {
   'use strict';
 
@@ -323,9 +321,6 @@
       triggerStateChange();
     });
 
-    if (!options.ignorePush && window._gaq) {
-      _gaq.push(['_trackPageview']); // google analytics
-    }
     if (!options.hash) {
       return;
     }


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/